### PR TITLE
Raise protocol's code quality

### DIFF
--- a/protocol/programs/protocol/src/contexts/init.rs
+++ b/protocol/programs/protocol/src/contexts/init.rs
@@ -18,7 +18,7 @@ pub struct InitCtx<'info> {
     pub system_program: Program<'info, System>,
 }
 
-impl<'info> InitCtx<'info> {
+impl InitCtx<'_> {
     pub fn process(&mut self, bump: u8, bump_authority: u8) -> Result<()> {
         let state = &mut self.state.load_init()?;
         **state = State {

--- a/protocol/programs/protocol/src/contexts/invoke_close_position.rs
+++ b/protocol/programs/protocol/src/contexts/invoke_close_position.rs
@@ -53,7 +53,7 @@ pub struct InvokeClosePositionCtx<'info> {
     pub invariant_program: Program<'info, Invariant>,
 }
 
-impl<'info> InvokeClosePositionCtx<'info> {
+impl InvokeClosePositionCtx<'_> {
     pub fn process(&self, index: u32, lower_tick_index: i32, upper_tick_index: i32) -> Result<()> {
         let InvokeClosePositionCtx {
             invariant_state,
@@ -99,7 +99,6 @@ impl<'info> InvokeClosePositionCtx<'info> {
             token_y_program: token_y_program.to_account_info(),
         };
         let ctx = CpiContext::new(program, accounts);
-        invariant::cpi::remove_position(ctx, index, lower_tick_index, upper_tick_index)?;
-        Ok(())
+        invariant::cpi::remove_position(ctx, index, lower_tick_index, upper_tick_index)
     }
 }

--- a/protocol/programs/protocol/src/contexts/invoke_create_position.rs
+++ b/protocol/programs/protocol/src/contexts/invoke_create_position.rs
@@ -1,14 +1,7 @@
 use anchor_lang::prelude::*;
-use invariant::{cpi::accounts::CreatePosition, decimals::*, program::Invariant};
+use invariant::{cpi::accounts::CreatePosition, program::Invariant};
 
 #[derive(Accounts)]
-#[instruction(
-    _lower_tick_index: i32,
-    _upper_tick_index: i32,
-    liquidity_delta: Liquidity,
-    slippage_limit_lower: Price,
-    slippage_limit_upper: Price
-)]
 pub struct InvokeCreatePositionCtx<'info> {
     pub invariant_program: Program<'info, Invariant>,
     #[account(mut)]
@@ -62,8 +55,8 @@ pub struct InvokeCreatePositionCtx<'info> {
 impl<'info> InvokeCreatePositionCtx<'info> {
     pub fn process(
         &mut self,
-        _lower_tick_index: i32,
-        _upper_tick_index: i32,
+        lower_tick_index: i32,
+        upper_tick_index: i32,
         liquidity_delta: u128,
         slippage_limit_lower: u128,
         slippage_limit_upper: u128,
@@ -119,8 +112,8 @@ impl<'info> InvokeCreatePositionCtx<'info> {
 
         invariant::cpi::create_position(
             ctx,
-            _lower_tick_index,
-            _upper_tick_index,
+            lower_tick_index,
+            upper_tick_index,
             invariant::decimals::Liquidity { v: liquidity_delta },
             invariant::decimals::Price {
                 v: slippage_limit_lower,
@@ -128,8 +121,6 @@ impl<'info> InvokeCreatePositionCtx<'info> {
             invariant::decimals::Price {
                 v: slippage_limit_upper,
             },
-        )?;
-
-        Ok(())
+        )
     }
 }

--- a/protocol/programs/protocol/src/contexts/invoke_update_seconds_per_liquidity.rs
+++ b/protocol/programs/protocol/src/contexts/invoke_update_seconds_per_liquidity.rs
@@ -59,13 +59,6 @@ impl<'info> InvokeUpdateSecondsPerLiquidityCtx<'info> {
         };
         let ctx = CpiContext::new(program, accounts);
 
-        invariant::cpi::update_seconds_per_liquidity(
-            ctx,
-            lower_tick_index,
-            upper_tick_index,
-            index,
-        )?;
-
-        Ok(())
+        invariant::cpi::update_seconds_per_liquidity(ctx, lower_tick_index, upper_tick_index, index)
     }
 }

--- a/protocol/programs/protocol/src/contexts/test.rs
+++ b/protocol/programs/protocol/src/contexts/test.rs
@@ -32,8 +32,6 @@ impl<'info> Test<'info> {
         };
         let ctx = CpiContext::new(program, accounts);
 
-        puppet::cpi::create_counter(ctx, state_bump)?;
-
-        Ok(())
+        puppet::cpi::create_counter(ctx, state_bump)
     }
 }

--- a/protocol/programs/protocol/src/contexts/token/deposit.rs
+++ b/protocol/programs/protocol/src/contexts/token/deposit.rs
@@ -1,6 +1,6 @@
 use crate::ErrorCode::*;
 use anchor_lang::prelude::*;
-use anchor_spl::token::{Token, TokenAccount, Transfer};
+use anchor_spl::token::{self, Token, TokenAccount, Transfer};
 
 use crate::states::{DerivedAccountIdentifier, State};
 
@@ -44,5 +44,11 @@ impl<'info> DepositCtx<'info> {
                 authority: self.owner.to_account_info(),
             },
         )
+    }
+}
+
+impl DepositCtx<'_> {
+    pub fn process(&self, amount: u64) -> Result<()> {
+        token::transfer(self.deposit_ctx(), amount)
     }
 }

--- a/protocol/programs/protocol/src/contexts/token/mint.rs
+++ b/protocol/programs/protocol/src/contexts/token/mint.rs
@@ -1,6 +1,6 @@
-use crate::ErrorCode::*;
+use crate::{get_signer, ErrorCode::*};
 use anchor_lang::prelude::*;
-use anchor_spl::token::{MintTo, Token, TokenAccount};
+use anchor_spl::token::{self, MintTo, Token, TokenAccount};
 
 use crate::states::{DerivedAccountIdentifier, State};
 
@@ -34,5 +34,14 @@ impl<'info> MintCtx<'info> {
                 authority: self.program_authority.to_account_info(),
             },
         )
+    }
+}
+
+impl MintCtx<'_> {
+    pub fn process(&self, amount: u64) -> Result<()> {
+        let state = &self.state.load()?;
+
+        let signer: &[&[&[u8]]] = get_signer!(state.bump_authority);
+        token::mint_to(self.mint_ctx().with_signer(signer), amount)
     }
 }

--- a/protocol/programs/protocol/src/contexts/token/withdraw.rs
+++ b/protocol/programs/protocol/src/contexts/token/withdraw.rs
@@ -1,6 +1,6 @@
-use crate::ErrorCode::*;
+use crate::{get_signer, ErrorCode::*};
 use anchor_lang::prelude::*;
-use anchor_spl::token::{Token, TokenAccount, Transfer};
+use anchor_spl::token::{self, Token, TokenAccount, Transfer};
 
 use crate::states::{DerivedAccountIdentifier, State};
 
@@ -44,5 +44,14 @@ impl<'info> WithdrawCtx<'info> {
                 authority: self.program_authority.clone(),
             },
         )
+    }
+}
+
+impl WithdrawCtx<'_> {
+    pub fn process(&self, amount: u64) -> Result<()> {
+        let state = &self.state.load()?;
+        let signer: &[&[&[u8]]] = get_signer!(state.bump_authority);
+
+        token::transfer(self.withdraw_ctx().with_signer(signer), amount)
     }
 }

--- a/protocol/programs/protocol/src/lib.rs
+++ b/protocol/programs/protocol/src/lib.rs
@@ -13,56 +13,37 @@ mod program_id {
     declare_id!("HTBzkQCWc2sbkn5WmLkPmQKKotaeeWgZ3RSD4Eg3f1MS");
 }
 
-const PROTOCOL_AUTHORITY_SEED: &str = "PROTOCOLAuthority";
-
 #[macro_export]
 macro_rules! get_signer {
     ($authority_bump: expr) => {
-        &[&[PROTOCOL_AUTHORITY_SEED.as_bytes(), &[$authority_bump]]]
+        &[&[b"PROTOCOLAuthority", &[$authority_bump]]]
     };
 }
 
 #[program]
 pub mod protocol {
 
-    use anchor_spl::token::{self};
-
     use super::*;
 
     pub fn init(ctx: Context<InitCtx>, bump_authority: u8) -> Result<()> {
         let bump = ctx.bumps.state;
-        ctx.accounts.process(bump, bump_authority)?;
-        Ok(())
+        ctx.accounts.process(bump, bump_authority)
     }
 
     pub fn test(ctx: Context<Test>, state_bump: u8) -> Result<()> {
-        ctx.accounts.process(state_bump)?;
-        Ok(())
+        ctx.accounts.process(state_bump)
     }
 
     pub fn mint(ctx: Context<MintCtx>, amount: u64) -> Result<()> {
-        let state = &ctx.accounts.state.load()?;
-
-        let signer: &[&[&[u8]]] = get_signer!(state.bump_authority);
-
-        // Mint the ??? token
-        token::mint_to(ctx.accounts.mint_ctx().with_signer(signer), amount)?;
-        Ok(())
+        ctx.accounts.process(amount)
     }
 
     pub fn deposit(ctx: Context<DepositCtx>, amount: u64) -> Result<()> {
-        // Deposit the ??? token
-        token::transfer(ctx.accounts.deposit_ctx(), amount)?;
-        Ok(())
+        ctx.accounts.process(amount)
     }
 
     pub fn withdraw(ctx: Context<WithdrawCtx>, amount: u64) -> Result<()> {
-        let state = &ctx.accounts.state.load()?;
-        let signer: &[&[&[u8]]] = get_signer!(state.bump_authority);
-
-        // Withdraw the ??? token
-        token::transfer(ctx.accounts.withdraw_ctx().with_signer(signer), amount)?;
-        Ok(())
+        ctx.accounts.process(amount)
     }
 
     pub fn invoke_update_seconds_per_liquidity(
@@ -72,8 +53,7 @@ pub mod protocol {
         index: i32,
     ) -> Result<()> {
         ctx.accounts
-            .process(lower_tick_index, upper_tick_index, index)?;
-        Ok(())
+            .process(lower_tick_index, upper_tick_index, index)
     }
 
     pub fn invoke_create_position(
@@ -90,8 +70,7 @@ pub mod protocol {
             liquidity_delta,
             slippage_limit_lower,
             slippage_limit_upper,
-        )?;
-        Ok(())
+        )
     }
 
     pub fn invoke_close_position(
@@ -101,7 +80,6 @@ pub mod protocol {
         upper_tick_index: i32,
     ) -> Result<()> {
         ctx.accounts
-            .process(index, lower_tick_index, upper_tick_index)?;
-        Ok(())
+            .process(index, lower_tick_index, upper_tick_index)
     }
 }


### PR DESCRIPTION
- return `Result<()>` where possible instead of using the `?` operator followed by `Ok(())`
- move all instruction logic to Context handlers (`process`)
- remove lifetime annotations where they are unnecessary
- remove `instruction`macro where it is unused
- move the `PROTOCOLAuthority` seed into the `get_signer` function to not require importing the constant separately